### PR TITLE
Implement list -o simple

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           make start
           make install-test-pod
-          make install-policy-viewer
+          make install-cilium-policy
       - name: Test
         working-directory: e2e
         run: make test

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -22,11 +22,11 @@ var dumpCmd = &cobra.Command{
 
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runDump(context.Background(), args[0])
+		return runDump(context.Background(), cmd.OutOrStdout(), args[0])
 	},
 }
 
-func runDump(ctx context.Context, name string) error {
+func runDump(ctx context.Context, w io.Writer, name string) error {
 	clientset, dynamicClient, _, err := createClients(ctx, name)
 	if err != nil {
 		return err
@@ -54,6 +54,6 @@ func runDump(ctx context.Context, name string) error {
 
 	var buf bytes.Buffer
 	json.Indent(&buf, data, "", "  ")
-	fmt.Println(buf.String())
+	buf.WriteTo(w)
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	OutputJson   = "json"
+	OutputSimple = "simple"
+)
+
 var rootOptions struct {
 	namespace     string
 	proxySelector string
@@ -18,7 +23,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&rootOptions.namespace, "namespace", "n", "default", "namespace of a pod")
 	rootCmd.PersistentFlags().StringVar(&rootOptions.proxySelector, "proxy-selector", "app.kubernetes.io/name=cilium-agent-proxy", "label selector to find the proxy pods")
 	rootCmd.PersistentFlags().Uint16Var(&rootOptions.proxyPort, "proxy-port", 8080, "port number of the proxy endpoints")
-	rootCmd.PersistentFlags().StringVarP(&rootOptions.output, "output", "o", "json", "output format")
+	rootCmd.PersistentFlags().StringVarP(&rootOptions.output, "output", "o", OutputSimple, "output format")
 }
 
 var rootCmd = &cobra.Command{}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -54,8 +54,8 @@ install-test-pod:
 	$(MAKE) --no-print-directory wait-for-workloads
 	$(KUBECTL) apply -f testdata/policy/l3.yaml
 
-.PHONY: install-policy-viewer
-install-policy-viewer:
+.PHONY: install-cilium-policy
+install-cilium-policy:
 	$(MAKE) -C ../ build
 	PODNAME=$$($(KUBECTL) get po -l app=ubuntu -o name | cut -d'/' -f2); \
 	$(KUBECTL) cp $(CILIUM_POLICY) $${PODNAME}:/tmp/; \

--- a/e2e/list_test.go
+++ b/e2e/list_test.go
@@ -64,7 +64,7 @@ func testList() {
 	It("should list applied policies", func() {
 		for _, c := range cases {
 			podName := onePodByLabelSelector(Default, "default", c.Selector)
-			result := runViewerSafe(Default, nil, "list", podName)
+			result := runViewerSafe(Default, nil, "list", "-o=json", podName)
 			testJson(Default, result, c.Expected)
 		}
 	})


### PR DESCRIPTION
This PR implements table-style output of the `list` command.

```
I have no name!@ubuntu-859f4496c7-z2bcz:/tmp$ ./cilium-policy list -n default self-55fdc9f7bc-rjh56 -o simple
DIRECTION KIND                NAMESPACE NAME
EGRESS    CiliumNetworkPolicy default   l3-egress
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>